### PR TITLE
googletest: 1.8.9000-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -889,6 +889,10 @@ repositories:
       version: eloquent
     status: maintained
   googletest:
+    doc:
+      type: git
+      url: https://github.com/ament/googletest.git
+      version: eloquent
     release:
       packages:
       - gmock_vendor


### PR DESCRIPTION
Increasing version of package(s) in repository `googletest` to `1.8.9000-1`:

- upstream repository: https://github.com/ament/googletest.git
- release repository: https://github.com/ros-staging/googletest-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `1.8.9000-1`
