### PR TITLE
googletest: 1.8.9000-5 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -896,7 +896,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/ros-staging/googletest-release.git
-      version: 1.8.9000-2
+      version: 1.8.9000-5
     source:
       type: git
       url: https://github.com/ros-staging/googletest.git


### PR DESCRIPTION
Increasing version of package(s) in repository `googletest` to `1.8.9000-5`:

- upstream repository: https://github.com/ament/googletest.git
- release repository: https://github.com/ros-staging/googletest-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.1`
- previous version for package: `1.8.9000-2`
