### PR TITLE
canary_template: 0.6.4-1 in 'dashing/addon.yaml' [bloom]

### DIFF
--- a/dashing/addon.yaml
+++ b/dashing/addon.yaml
@@ -5,6 +5,16 @@
 release_platforms:
   ubuntu:
   - bionic
-repositories: []
+repositories:
+  canary_template:
+    release:
+      tags:
+        release: release/dashing/{package}/{version}
+      url: https://github.com/nuclearsandwich/canary_template-release.git
+      version: 0.6.4-1
+    source:
+      type: git
+      url: https://github.com/nuclearsandwich/canary-template
+      version: latest
 type: distribution
 version: 2


### PR DESCRIPTION
Increasing version of package(s) in repository `canary_template` to `0.6.4-1`:

- upstream repository: https://github.com/nuclearsandwich/canary-template.git
- release repository: https://github.com/nuclearsandwich/canary_template-release.git
- distro file: `dashing/addon.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`
