### PR TITLE
canary_template: 0.6.4-1 in 'dashing/addon.yaml' [bloom]

### DIFF
--- a/dashing/addon.yaml
+++ b/dashing/addon.yaml
@@ -9,7 +9,7 @@ repositories:
   canary_template:
     release:
       tags:
-        release: release/dashing/{package}/{version}
+        release: release/addon/{package}/{version}
       url: https://github.com/nuclearsandwich/canary_template-release.git
       version: 0.6.4-1
     source:
@@ -17,6 +17,6 @@ repositories:
       url: https://github.com/nuclearsandwich/canary-template
       version: latest
 tags:
-  - addon
+- addon
 type: distribution
 version: 2


### PR DESCRIPTION
Increasing version of package(s) in repository `canary_template` to `0.6.4-1`:

- upstream repository: https://github.com/nuclearsandwich/canary-template.git
- release repository: https://github.com/nuclearsandwich/canary_template-release.git
- distro file: `dashing/addon.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.6.4-1`
