### PR TITLE
canary_template: 0.6.4-2 in 'dashing/addon.yaml' [bloom]

### DIFF
--- a/dashing/addon.yaml
+++ b/dashing/addon.yaml
@@ -11,7 +11,7 @@ repositories:
       tags:
         release: release/addon/{package}/{version}
       url: https://github.com/nuclearsandwich/canary_template-release.git
-      version: 0.6.4-1
+      version: 0.6.4-2
     source:
       type: git
       url: https://github.com/nuclearsandwich/canary-template


### PR DESCRIPTION
Increasing version of package(s) in repository `canary_template` to `0.6.4-2`:

- upstream repository: https://github.com/nuclearsandwich/canary-template.git
- release repository: https://github.com/nuclearsandwich/canary_template-release.git
- distro file: `dashing/addon.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.6.4-1`
